### PR TITLE
Add BeeHive skeleton with Auth0 and YARP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# BeeHive
+# BeeHive Management Web App
+
+This repository contains a demo skeleton for the BeeHive management application using Angular and .NET microservices.
+
+## Structure
+
+- `client` – Angular application with Auth0 integration.
+- `server/HiveService` – .NET 9 service exposing hive APIs.
+- `server/Gateway` – YARP gateway securing all API calls.
+- `docker` – Docker compose configuration.
+
+## Auth0 Configuration
+
+Set the following environment variables before running the services:
+
+- `AUTH0_DOMAIN`
+- `AUTH0_AUDIENCE`
+- `AUTH0_CLIENT_ID` (for the frontend)
+
+These variables are consumed by the Angular app and the microservices to validate tokens.
+
+## Docker
+
+Run the stack using Docker Compose:
+
+```bash
+docker compose -f docker/docker-compose.yml up
+```
+
+This will start the gateway and hive service on the internal `kaiju-net` network.

--- a/client/src/app/auth/auth.config.service.ts
+++ b/client/src/app/auth/auth.config.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { AuthClientConfig, AuthConfig } from '@auth0/auth0-angular';
+
+@Injectable({ providedIn: 'root' })
+export class AuthConfigService {
+  constructor(private config: AuthClientConfig) {}
+
+  load(): void {
+    const authConfig: AuthConfig = {
+      domain: window.env.AUTH0_DOMAIN,
+      clientId: window.env.AUTH0_CLIENT_ID,
+      audience: window.env.AUTH0_AUDIENCE,
+      useRefreshTokens: true,
+      cacheLocation: 'localstorage'
+    };
+    this.config.set(authConfig);
+  }
+}

--- a/client/src/app/auth/auth.guard.ts
+++ b/client/src/app/auth/auth.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { AuthService } from '@auth0/auth0-angular';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
+    return this.auth.isAuthenticated$.pipe(
+      map((loggedIn) => {
+        if (!loggedIn) {
+          this.auth.loginWithRedirect({ appState: { target: state.url } });
+        }
+        return loggedIn;
+      })
+    );
+  }
+}

--- a/client/src/app/auth/auth.interceptor.ts
+++ b/client/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { AuthService } from '@auth0/auth0-angular';
+import { Observable, from } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private auth: AuthService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return from(this.auth.getAccessTokenSilently()).pipe(
+      switchMap(token => {
+        const authReq = req.clone({
+          setHeaders: { Authorization: `Bearer ${token}` }
+        });
+        return next.handle(authReq);
+      })
+    );
+  }
+}

--- a/client/src/app/hives/hive-list/hive-list.component.html
+++ b/client/src/app/hives/hive-list/hive-list.component.html
@@ -1,0 +1,15 @@
+<div class="p-mb-3">
+  <p-chip *ngFor="let status of statuses"
+          [label]="status"
+          class="p-mr-2"
+          [class.p-chip-highlight]="statusFilter.value === status"
+          (click)="statusFilter.setValue(status); loadHives();">
+  </p-chip>
+</div>
+
+<div *ngFor="let hive of hives" class="p-card p-mb-2">
+  <div class="p-card-title">{{ hive.hiveName }}</div>
+  <div class="p-card-content">
+    Location: {{ hive.location }} - Status: {{ hive.healthStatus }}
+  </div>
+</div>

--- a/client/src/app/hives/hive-list/hive-list.component.ts
+++ b/client/src/app/hives/hive-list/hive-list.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { HiveService, Hive } from '../hive.service';
+
+@Component({
+  selector: 'app-hive-list',
+  templateUrl: './hive-list.component.html',
+})
+export class HiveListComponent implements OnInit {
+  hives: Hive[] = [];
+  statusFilter = new FormControl('all');
+  statuses = ['all', 'critical', 'fair', 'good'];
+
+  constructor(private hiveService: HiveService) {}
+
+  ngOnInit(): void {
+    this.loadHives();
+  }
+
+  loadHives(): void {
+    this.hiveService.getHives(this.statusFilter.value).subscribe(h => this.hives = h);
+  }
+}

--- a/client/src/app/hives/hive.service.ts
+++ b/client/src/app/hives/hive.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Hive {
+  hiveId: string;
+  location: string;
+  hiveName: string;
+  queenAge: number;
+  colonyStrength: number;
+  healthStatus: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class HiveService {
+  private baseUrl = '/api/hives';
+
+  constructor(private http: HttpClient) {}
+
+  getHives(status?: string): Observable<Hive[]> {
+    let params = new HttpParams();
+    if (status && status !== 'all') {
+      params = params.set('status', status);
+    }
+    return this.http.get<Hive[]>(this.baseUrl, { params });
+  }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  gateway:
+    build: ../server/Gateway
+    environment:
+      - AUTH0_DOMAIN=${AUTH0_DOMAIN}
+      - AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
+    networks:
+      - kaiju-net
+    ports:
+      - "8080:80"
+  hiveservice:
+    build: ../server/HiveService/HiveService.API
+    environment:
+      - AUTH0_DOMAIN=${AUTH0_DOMAIN}
+      - AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
+    networks:
+      - kaiju-net
+
+networks:
+  kaiju-net:
+    driver: bridge

--- a/server/Gateway/Dockerfile
+++ b/server/Gateway/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-preview AS base
+WORKDIR /app
+
+COPY . .
+
+ENV ASPNETCORE_URLS=http://+:80
+
+ENTRYPOINT ["dotnet", "Gateway.dll"]

--- a/server/Gateway/Program.cs
+++ b/server/Gateway/Program.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Yarp.ReverseProxy.Transforms;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("Yarp"));
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Auth0:Domain"];
+        options.Audience = builder.Configuration["Auth0:Audience"];
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidAudience = builder.Configuration["Auth0:Audience"],
+            ValidIssuer = builder.Configuration["Auth0:Domain"],
+        };
+    });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy =>
+        policy.RequireClaim("permissions", "admin"));
+});
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapReverseProxy(proxyPipeline =>
+{
+    proxyPipeline.Use((context, next) =>
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var token = context.GetTokenAsync("access_token").Result;
+            if (token != null)
+            {
+                context.Request.Headers["Authorization"] = $"Bearer {token}";
+            }
+        }
+        return next();
+    });
+});
+
+app.Run();

--- a/server/Gateway/appsettings.json
+++ b/server/Gateway/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Auth0": {
+    "Domain": "https://YOUR_DOMAIN/",
+    "Audience": "YOUR_AUDIENCE"
+  },
+  "Yarp": {
+    "Routes": [
+      {
+        "RouteId": "hive",
+        "ClusterId": "hiveCluster",
+        "Match": {
+          "Path": "/api/hives/{**catch-all}"
+        },
+        "AuthorizationPolicy": "Default"
+      }
+    ],
+    "Clusters": {
+      "hiveCluster": {
+        "Destinations": {
+          "hive": { "Address": "http://hiveservice:5000/" }
+        }
+      }
+    }
+  }
+}

--- a/server/HiveService/HiveService.API/Controllers/HiveController.cs
+++ b/server/HiveService/HiveService.API/Controllers/HiveController.cs
@@ -1,0 +1,40 @@
+using HiveService.API.Domain;
+using HiveService.API.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HiveService.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class HiveController : ControllerBase
+    {
+        private readonly HiveDbContext _context;
+
+        public HiveController(HiveDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Hive>>> GetHives([FromQuery] string? status)
+        {
+            var query = _context.Hives.AsQueryable();
+            if (!string.IsNullOrEmpty(status) && status != "all")
+            {
+                query = query.Where(h => h.HealthStatus == status);
+            }
+            return await query.ToListAsync();
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Hive>> CreateHive(Hive hive)
+        {
+            _context.Hives.Add(hive);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetHives), new { id = hive.HiveId }, hive);
+        }
+    }
+}

--- a/server/HiveService/HiveService.API/Dockerfile
+++ b/server/HiveService/HiveService.API/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-preview AS base
+WORKDIR /app
+
+COPY . .
+
+ENV ASPNETCORE_URLS=http://+:5000
+
+ENTRYPOINT ["dotnet", "HiveService.API.dll"]

--- a/server/HiveService/HiveService.API/Domain/Hive.cs
+++ b/server/HiveService/HiveService.API/Domain/Hive.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace HiveService.API.Domain
+{
+    public class Hive
+    {
+        [Key]
+        public Guid HiveId { get; set; }
+        public string Location { get; set; } = string.Empty;
+        public string HiveName { get; set; } = string.Empty;
+        public int QueenAge { get; set; }
+        public int ColonyStrength { get; set; }
+        public string HealthStatus { get; set; } = string.Empty;
+    }
+}

--- a/server/HiveService/HiveService.API/Infrastructure/HiveDbContext.cs
+++ b/server/HiveService/HiveService.API/Infrastructure/HiveDbContext.cs
@@ -1,0 +1,15 @@
+using HiveService.API.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace HiveService.API.Infrastructure
+{
+    public class HiveDbContext : DbContext
+    {
+        public HiveDbContext(DbContextOptions<HiveDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Hive> Hives => Set<Hive>();
+    }
+}

--- a/server/HiveService/HiveService.API/Program.cs
+++ b/server/HiveService/HiveService.API/Program.cs
@@ -1,0 +1,36 @@
+using HiveService.API.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.Authority = builder.Configuration["Auth0:Domain"];
+    options.Audience = builder.Configuration["Auth0:Audience"];
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidAudience = builder.Configuration["Auth0:Audience"],
+        ValidIssuer = builder.Configuration["Auth0:Domain"],
+    };
+});
+
+builder.Services.AddDbContext<HiveDbContext>(options =>
+    options.UseInMemoryDatabase("hives"));
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();


### PR DESCRIPTION
## Summary
- set up Angular client with Auth0 services/guard/interceptor
- add Hive list component
- add HiveService .NET API with JWT auth
- implement YARP gateway forwarding auth headers
- provide docker compose for gateway and hive service

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ff328bf3c8328b1ef98d8818f8346